### PR TITLE
Refactor: 예약 동작 로직 수정 (Redis, DB 동기화)

### DIFF
--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/cache/QueueReservationCache.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/cache/QueueReservationCache.java
@@ -1,0 +1,11 @@
+package com.project.tableforyou.domain.reservationrefactor.cache;
+
+public record QueueReservationCache(
+        Long userId,
+        String username,
+        int reservationNumber
+) {
+    public static QueueReservationCache of(Long userId, String username, int reservationNumber) {
+        return new QueueReservationCache(userId, username, reservationNumber);
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/cache/TimeSlotReservationCache.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/cache/TimeSlotReservationCache.java
@@ -1,0 +1,13 @@
+package com.project.tableforyou.domain.reservationrefactor.cache;
+
+import com.project.tableforyou.domain.reservation.entity.TimeSlot;
+
+public record TimeSlotReservationCache(
+        Long userId,
+        String username,
+        TimeSlot timeSlot
+) {
+    public static TimeSlotReservationCache of(Long userId, String username, TimeSlot timeSlot) {
+        return new TimeSlotReservationCache(userId, username, timeSlot);
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/controller/QueueReservationController.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/controller/QueueReservationController.java
@@ -1,0 +1,81 @@
+package com.project.tableforyou.domain.reservationrefactor.controller;
+
+import com.project.tableforyou.common.utils.api.ApiUtil;
+import com.project.tableforyou.domain.reservationrefactor.service.ReservationLockManager;
+import com.project.tableforyou.domain.reservationrefactor.service.queue.QueueReservationCommandService;
+import com.project.tableforyou.domain.reservationrefactor.service.queue.QueueReservationQueryService;
+import com.project.tableforyou.security.auth.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/restaurants")
+public class QueueReservationController {
+    private final ReservationLockManager reservationLockManager;
+    private final QueueReservationQueryService queueReservationQueryService;
+    private final QueueReservationCommandService queueReservationCommandService;
+
+    @PostMapping("/{restaurantId}/queue-reservations")
+    public ResponseEntity<?> createReservation(
+            @PathVariable Long restaurantId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        reservationLockManager.saveQueueReservation(
+                principalDetails.getId(),
+                principalDetails.getUsername(),
+                restaurantId
+        );
+
+        return ResponseEntity.ok(ApiUtil.from("예약자 추가 성공."));
+    }
+
+    @DeleteMapping("/{restaurantId}/queue-reservations")
+    public ResponseEntity<?> cancelReservation(
+            @PathVariable Long restaurantId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        queueReservationCommandService.cancel(
+                principalDetails.getId(),
+                restaurantId
+        );
+
+        return ResponseEntity.ok(ApiUtil.from("예약자 취소 성공."));
+    }
+
+    @PatchMapping("/{restaurantId}/queue-reservations")
+    public ResponseEntity<?> enterReservation(
+            @PathVariable Long restaurantId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        queueReservationCommandService.markAsEntered(
+                principalDetails.getId(),
+                restaurantId
+        );
+
+        return ResponseEntity.ok(ApiUtil.from("예약자 입장 성공."));
+    }
+
+    @GetMapping("/{restaurantId}/queue-reservations")
+    public ResponseEntity<?> getUserWaitingPosition(
+            @PathVariable Long restaurantId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        return ResponseEntity.ok(
+                ApiUtil.from(
+                        queueReservationQueryService.getUserWaitingPosition(
+                                principalDetails.getId(),
+                                restaurantId
+                        )
+                )
+        );
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/controller/TimeSlotReservationController.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/controller/TimeSlotReservationController.java
@@ -1,0 +1,97 @@
+package com.project.tableforyou.domain.reservationrefactor.controller;
+
+import com.project.tableforyou.common.utils.api.ApiUtil;
+import com.project.tableforyou.domain.reservation.entity.TimeSlot;
+import com.project.tableforyou.domain.reservationrefactor.dto.TimeSlotReservationDto;
+import com.project.tableforyou.domain.reservationrefactor.service.ReservationLockManager;
+import com.project.tableforyou.domain.reservationrefactor.service.timeslot.TimeSlotReservationCommandService;
+import com.project.tableforyou.domain.reservationrefactor.service.timeslot.TimeSlotReservationQueryService;
+import com.project.tableforyou.security.auth.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/restaurants")
+public class TimeSlotReservationController {
+    private final ReservationLockManager reservationLockManager;
+    private final TimeSlotReservationQueryService timeSlotReservationQueryService;
+    private final TimeSlotReservationCommandService timeSlotReservationCommandService;
+
+    @PostMapping("/{restaurantId}/timeslot-reservations")
+    public ResponseEntity<?> createReservation(
+            @PathVariable Long restaurantId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody TimeSlotReservationDto.Create createReq
+    ) {
+        reservationLockManager.saveTimeSlotReservation(
+                principalDetails.getId(),
+                principalDetails.getUsername(),
+                restaurantId,
+                createReq
+        );
+
+        return ResponseEntity.ok(ApiUtil.from("예약자 추가 성공."));
+    }
+
+    @DeleteMapping("/{restaurantId}/timeslot-reservations")
+    public ResponseEntity<?> cancelReservation(
+            @PathVariable Long restaurantId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody TimeSlotReservationDto.Request request
+    ) {
+        timeSlotReservationCommandService.cancel(
+                principalDetails.getId(),
+                restaurantId,
+                request
+        );
+
+        return ResponseEntity.ok(ApiUtil.from("예약자 취소 성공."));
+    }
+
+    @PatchMapping("/{restaurantId}/timeslot-reservations")
+    public ResponseEntity<?> enterReservation(
+            @PathVariable Long restaurantId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody TimeSlotReservationDto.Request request
+    ) {
+        timeSlotReservationCommandService.markAsEntered(
+                principalDetails.getId(),
+                restaurantId,
+                request
+        );
+
+        return ResponseEntity.ok(ApiUtil.from("예약자 입장 성공."));
+    }
+
+    @GetMapping("/{restaurantId}/timeslot-reservations")
+    public ResponseEntity<?> getUserWaitingPosition(
+            @PathVariable Long restaurantId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestParam(value = "date") LocalDate date,
+            @RequestParam(value = "time-slot") TimeSlot timeSlot
+    ) {
+        return ResponseEntity.ok(
+                ApiUtil.from(
+                        timeSlotReservationQueryService.confirmOrCacheMyReservation(
+                                principalDetails.getId(),
+                                restaurantId,
+                                date,
+                                timeSlot
+                        )
+                )
+        );
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/dto/TimeSlotReservationDto.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/dto/TimeSlotReservationDto.java
@@ -1,0 +1,19 @@
+package com.project.tableforyou.domain.reservationrefactor.dto;
+
+import com.project.tableforyou.domain.reservation.entity.TimeSlot;
+
+import java.time.LocalDate;
+
+public class TimeSlotReservationDto {
+
+    public record Create(
+            int availableSeats,
+            LocalDate date,
+            TimeSlot timeSlot
+    ) { }
+
+    public record Request(
+            LocalDate date,
+            TimeSlot timeSlot
+    ) { }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/entity/QueueReservation.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/entity/QueueReservation.java
@@ -1,0 +1,92 @@
+package com.project.tableforyou.domain.reservationrefactor.entity;
+
+import com.project.tableforyou.domain.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "queue_reservation")
+public class QueueReservation extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(name = "restaurant_id", nullable = false)
+    private Long restaurantId;
+
+    // 예약 날짜
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    // 대기순번 (1번부터 시작)
+    @Column(name = "reservation_number")
+    private int reservationNumber;
+
+    // 예약 취소 여부
+    @Column(name = "is_canceled", nullable = false)
+    private boolean isCanceled = false;
+
+    // 입장 완료 여부
+    @Column(name = "is_entered", nullable = false)
+    private boolean isEntered = false;
+
+    // 취소 시각
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+
+    // 입장 시각
+    @Column(name = "entered_at")
+    private LocalDateTime enteredAt;
+
+    @Builder
+    public QueueReservation(Long userId, String username, Long restaurantId, LocalDate date, int reservationNumber) {
+        this.userId = userId;
+        this.username = username;
+        this.restaurantId = restaurantId;
+        this.date = date;
+        this.reservationNumber = reservationNumber;
+    }
+
+    public void cancelReservation() {
+        if (this.isCanceled) {
+            throw new IllegalStateException("이미 취소된 예약입니다.");
+        }
+
+        if (this.isEntered) {
+            throw new IllegalStateException("이미 입장한 예약은 취소할 수 없습니다.");
+        }
+
+        this.isCanceled = true;
+        this.canceledAt = LocalDateTime.now();
+    }
+
+    public void enterRestaurant() {
+        if (this.isCanceled) {
+            throw new IllegalStateException("취소된 예약은 입장할 수 없습니다.");
+        }
+
+        if (this.isEntered) {
+            throw new IllegalStateException("이미 입장한 예약입니다.");
+        }
+
+        this.isEntered = true;
+        this.enteredAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/entity/TimeSlotReservation.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/entity/TimeSlotReservation.java
@@ -1,0 +1,93 @@
+package com.project.tableforyou.domain.reservationrefactor.entity;
+
+import com.project.tableforyou.domain.BaseTimeEntity;
+import com.project.tableforyou.domain.reservation.entity.TimeSlot;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "timeslot_reservation")
+public class TimeSlotReservation extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(name = "restaurant_id", nullable = false)
+    private Long restaurantId;
+
+    // 예약 날짜
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    // 예약 시간대
+    @Column(name = "time_slot", nullable = false)
+    private TimeSlot timeSlot;
+
+    // 예약 취소 여부
+    @Column(name = "is_canceled", nullable = false)
+    private boolean isCanceled = false;
+
+    // 입장 완료 여부
+    @Column(name = "is_entered", nullable = false)
+    private boolean isEntered = false;
+
+    // 취소 시각
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+
+    // 입장 시각
+    @Column(name = "entered_at")
+    private LocalDateTime enteredAt;
+
+    @Builder
+    public TimeSlotReservation(Long userId, String username, Long restaurantId, LocalDate date, TimeSlot timeSlot) {
+        this.userId = userId;
+        this.username = username;
+        this.restaurantId = restaurantId;
+        this.date = date;
+        this.timeSlot = timeSlot;
+    }
+
+    public void cancelReservation() {
+        if (this.isCanceled) {
+            throw new IllegalStateException("이미 취소된 예약입니다.");
+        }
+
+        if (this.isEntered) {
+            throw new IllegalStateException("이미 입장한 예약은 취소할 수 없습니다.");
+        }
+
+        this.isCanceled = true;
+        this.canceledAt = LocalDateTime.now();
+    }
+
+    public void enterRestaurant() {
+        if (this.isCanceled) {
+            throw new IllegalStateException("취소된 예약은 입장할 수 없습니다.");
+        }
+
+        if (this.isEntered) {
+            throw new IllegalStateException("이미 입장한 예약입니다.");
+        }
+
+        this.isEntered = true;
+        this.enteredAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/redis/RedisRepository.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/redis/RedisRepository.java
@@ -1,0 +1,61 @@
+package com.project.tableforyou.domain.reservationrefactor.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRepository {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void set(String key, Object value) {
+        redisTemplate.opsForValue().set(key, value);
+    }
+
+    public <T> T get(String key, Class<T> type) {
+        Object value = redisTemplate.opsForValue().get(key);
+        if (value == null) return null;
+
+        if (type.isInstance(value)) {
+            return type.cast(value);
+        }
+
+        throw new IllegalStateException("Cannot cast value to " + type.getName());
+    }
+
+    public <T> void hashPut(String key, Object hashKey, T object) {
+        redisTemplate.opsForHash().put(key, String.valueOf(hashKey), object);
+    }
+
+    public <T> T hashGet(String key, Object hashKey, Class<T> type) {
+        Object value = redisTemplate.opsForHash().get(key, String.valueOf(hashKey));
+        if (value == null) return null;
+
+        if (type.isInstance(value)) {
+            return type.cast(value);
+        }
+
+        throw new IllegalStateException("Cannot cast value to " + type.getName());
+    }
+
+    public void hashDel(String key, Object hashKey) {
+        redisTemplate.opsForHash().delete(key, String.valueOf(hashKey));
+    }
+
+    public void expire(String key, long seconds) {
+        redisTemplate.expire(key, Duration.ofSeconds(seconds));
+    }
+
+    public boolean hashExisted(String key, Object hashKey) {
+        return redisTemplate.opsForHash().hasKey(key, String.valueOf(hashKey));
+    }
+
+    public Long increase(String key) {
+        return stringRedisTemplate.opsForValue().increment(key);
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/redis/queue/QueueReservationRedisService.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/redis/queue/QueueReservationRedisService.java
@@ -1,0 +1,86 @@
+package com.project.tableforyou.domain.reservationrefactor.redis.queue;
+
+import com.project.tableforyou.domain.reservationrefactor.cache.QueueReservationCache;
+import com.project.tableforyou.domain.reservationrefactor.redis.RedisRepository;
+import com.project.tableforyou.domain.reservationrefactor.redis.util.TimeUtil;
+import com.project.tableforyou.domain.reservationrefactor.redis.util.constants.ReservationConstants;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QueueReservationRedisService {
+    private final RedisRepository redisRepository;
+
+    public void saveReservation(Long restaurantId, QueueReservationCache reservation) {
+        String key = ReservationConstants.getQueueReservationKey(restaurantId);
+        redisRepository.hashPut(key, reservation.userId(), reservation);
+        redisRepository.expire(key, TimeUtil.getExpireSeconds());
+    }
+
+    public boolean isAlreadyReserved(Long userId, Long restaurantId) {
+        return redisRepository.hashExisted(ReservationConstants.getQueueReservationKey(restaurantId), userId);
+    }
+
+    public QueueReservationCache getReservation(Long userId, Long restaurantId) {
+        return redisRepository.hashGet(
+                ReservationConstants.getQueueReservationKey(restaurantId),
+                userId,
+                QueueReservationCache.class
+        );
+    }
+
+    public void setReservationNumberCounter(Long restaurantId, int reservationNumber) {
+        String key = ReservationConstants.getQueueReservationNumberKey(restaurantId);
+        redisRepository.set(key, reservationNumber);
+        redisRepository.expire(key, TimeUtil.getExpireSeconds());
+    }
+
+    public int generateNextReservationNumber(Long restaurantId) {
+        String key = ReservationConstants.getQueueReservationNumberKey(restaurantId);
+        Long number = redisRepository.increase(key);
+        redisRepository.expire(key, TimeUtil.getExpireSeconds());
+        return number != null ? number.intValue() : 1;
+    }
+
+    public void markAsEntered(Long userId, Long restaurantId) {
+        String key = ReservationConstants.getQueueReservationKey(restaurantId);
+        String enteredKey = ReservationConstants.getQueueEnteredCountKey(restaurantId);
+        redisRepository.hashDel(key, userId);
+        redisRepository.increase(enteredKey);
+        redisRepository.expire(enteredKey, TimeUtil.getExpireSeconds());
+    }
+
+    public void cancelReservation(Long userId, Long restaurantId) {
+        String key = ReservationConstants.getQueueReservationKey(restaurantId);
+        String canceledKey = ReservationConstants.getQueueCanceledCountKey(restaurantId);
+        redisRepository.hashDel(key, userId);
+        redisRepository.increase(canceledKey);
+        redisRepository.expire(canceledKey, TimeUtil.getExpireSeconds());
+    }
+
+    public void setEnteredCount(Long restaurantId, int count) {
+        String key = ReservationConstants.getQueueEnteredCountKey(restaurantId);
+        redisRepository.set(key, count);
+        redisRepository.expire(key, TimeUtil.getExpireSeconds());
+    }
+
+    public int getEnteredCount(Long restaurantId) {
+        String key = ReservationConstants.getQueueEnteredCountKey(restaurantId);
+        Integer count = redisRepository.get(key, Integer.class);
+        return count == null ? 0 : count;
+    }
+
+    public void setCanceledCount(Long restaurantId, int count) {
+        String key = ReservationConstants.getQueueCanceledCountKey(restaurantId);
+        redisRepository.set(key, count);
+        redisRepository.expire(key, TimeUtil.getExpireSeconds());
+    }
+
+    public int getCanceledCount(Long restaurantId) {
+        String key = ReservationConstants.getQueueCanceledCountKey(restaurantId);
+        Integer count = redisRepository.get(key, Integer.class);
+        return count == null ? 0 : count;
+    }
+}
+

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/redis/timeslot/TimeSlotReservationRedisService.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/redis/timeslot/TimeSlotReservationRedisService.java
@@ -1,0 +1,54 @@
+package com.project.tableforyou.domain.reservationrefactor.redis.timeslot;
+
+import com.project.tableforyou.domain.reservation.entity.TimeSlot;
+import com.project.tableforyou.domain.reservationrefactor.cache.TimeSlotReservationCache;
+import com.project.tableforyou.domain.reservationrefactor.redis.RedisRepository;
+import com.project.tableforyou.domain.reservationrefactor.redis.util.TimeUtil;
+import com.project.tableforyou.domain.reservationrefactor.redis.util.constants.ReservationConstants;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TimeSlotReservationRedisService {
+    private final RedisRepository redisRepository;
+
+    public void saveReservation(Long restaurantId, String date, TimeSlotReservationCache reservation) {
+        String key = ReservationConstants.getTimeSlotReservationKey(restaurantId, date, reservation.timeSlot());
+        redisRepository.hashPut(key, reservation.userId(), reservation);
+        redisRepository.expire(key, TimeUtil.getExpireSeconds());
+    }
+
+    public boolean isAlreadyReserved(Long userId, Long restaurantId, String date, TimeSlot timeSlot) {
+        return redisRepository.hashExisted(
+                ReservationConstants.getTimeSlotReservationKey(restaurantId, date, timeSlot),
+                userId
+        );
+    }
+
+    public TimeSlotReservationCache getReservation(Long userId, Long restaurantId, String date, TimeSlot timeSlot) {
+        return redisRepository.hashGet(
+                ReservationConstants.getTimeSlotReservationKey(restaurantId, date, timeSlot),
+                userId,
+                TimeSlotReservationCache.class
+        );
+    }
+
+    public void setReservationNumberCounter(Long restaurantId, String date, TimeSlot timeSlot, int reservationNumber) {
+        String key = ReservationConstants.getTimeSlotReservationNumberKey(restaurantId, date, timeSlot);
+        redisRepository.set(key, reservationNumber);
+        redisRepository.expire(key, TimeUtil.getExpireSeconds());
+    }
+
+    public int generateNextReservationNumber(Long restaurantId, String date, TimeSlot timeSlot) {
+        String key = ReservationConstants.getTimeSlotReservationNumberKey(restaurantId, date, timeSlot);
+        Long number = redisRepository.increase(key);
+        redisRepository.expire(key, TimeUtil.getExpireSeconds());
+        return number != null ? number.intValue() : 1;
+    }
+
+    public void cancelReservation(Long userId, Long restaurantId, String date, TimeSlot timeSlot) {
+        String key = ReservationConstants.getTimeSlotReservationKey(restaurantId, date, timeSlot);
+        redisRepository.hashDel(key, userId);
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/redis/util/TimeUtil.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/redis/util/TimeUtil.java
@@ -1,0 +1,12 @@
+package com.project.tableforyou.domain.reservationrefactor.redis.util;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class TimeUtil {
+
+    public static long getExpireSeconds() {
+        return Duration.between(LocalDateTime.now(), LocalDate.now().plusDays(1).atStartOfDay()).getSeconds();
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/redis/util/constants/ReservationConstants.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/redis/util/constants/ReservationConstants.java
@@ -1,0 +1,59 @@
+package com.project.tableforyou.domain.reservationrefactor.redis.util.constants;
+
+import com.project.tableforyou.domain.reservation.entity.TimeSlot;
+
+public final class ReservationConstants {
+
+    private ReservationConstants() { }
+
+    public static final String RESERVATION_KEY_PREFIX = "reservation:";
+
+    private static final String QUEUE_RESERVATION_KEY = "queue:reserved::%d";
+    private static final String QUEUE_RESERVATION_NUMBER_KEY = "queue:reservation-number::%d";
+    private static final String QUEUE_ENTERED_COUNT_KEY = "queue:entered:count::%d";
+    private static final String QUEUE_CANCELED_COUNT_KEY = "queue:canceled:count::%d";
+    private static final String TIME_SLOT_RESERVATION_KEY = "timeslot:reserved::%d:%s:%s";
+    private static final String TIME_SLOT_RESERVATION_NUMBER_KEY = "timeslot:reservation-number:%d:%s:%s";
+
+    /**
+     * queue 예약 key
+     */
+    public static String getQueueReservationKey(Long restaurantId) {
+        return String.format(QUEUE_RESERVATION_KEY, restaurantId);
+    }
+
+    /**
+     * queue 예약 번호 key
+     */
+    public static String getQueueReservationNumberKey(Long restaurantId) {
+        return String.format(QUEUE_RESERVATION_NUMBER_KEY, restaurantId);
+    }
+
+    /**
+     * time slot 예약 키
+     */
+    public static String getTimeSlotReservationKey(Long restaurantId, String date, TimeSlot timeSlot) {
+        return String.format(TIME_SLOT_RESERVATION_KEY, restaurantId, date, timeSlot);
+    }
+
+    /**
+     * time slot 예약 번호 key
+     */
+    public static String getTimeSlotReservationNumberKey(Long restaurantId, String date, TimeSlot timeSlot) {
+        return String.format(TIME_SLOT_RESERVATION_NUMBER_KEY, restaurantId, date, timeSlot);
+    }
+
+    /**
+     * 입장 카운트 key
+     */
+    public static String getQueueEnteredCountKey(Long restaurantId) {
+        return String.format(QUEUE_ENTERED_COUNT_KEY, restaurantId);
+    }
+
+    /**
+     * 취소 카운트 key
+     */
+    public static String getQueueCanceledCountKey(Long restaurantId) {
+        return String.format(QUEUE_CANCELED_COUNT_KEY, restaurantId);
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/repository/QueueReservationRepository.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/repository/QueueReservationRepository.java
@@ -1,0 +1,19 @@
+package com.project.tableforyou.domain.reservationrefactor.repository;
+
+import com.project.tableforyou.domain.reservationrefactor.entity.QueueReservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface QueueReservationRepository extends JpaRepository<QueueReservation, Long> {
+    int countByRestaurantIdAndDate(Long restaurantId, LocalDate date);
+
+    Optional<QueueReservation> findByUserIdAndRestaurantIdAndDateAndIsCanceledFalse(
+            Long userId, Long restaurantId, LocalDate date
+    );
+
+    int countByRestaurantIdAndDateAndIsEnteredTrue(Long restaurantId, LocalDate date);
+
+    int countByRestaurantIdAndDateAndIsCanceledTrue(Long restaurantId, LocalDate date);
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/repository/TimeSlotReservationRepository.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/repository/TimeSlotReservationRepository.java
@@ -1,0 +1,16 @@
+package com.project.tableforyou.domain.reservationrefactor.repository;
+
+import com.project.tableforyou.domain.reservation.entity.TimeSlot;
+import com.project.tableforyou.domain.reservationrefactor.entity.TimeSlotReservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface TimeSlotReservationRepository extends JpaRepository<TimeSlotReservation, Long> {
+    int countByRestaurantIdAndDateAndTimeSlotAndIsCanceledFalse(Long restaurantId, LocalDate date, TimeSlot timeSlot);
+
+    Optional<TimeSlotReservation> findByUserIdAndRestaurantIdAndDateAndTimeSlotAndIsCanceledFalse(
+            Long userId, Long restaurantId, LocalDate date, TimeSlot timeSlot
+    );
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/ReservationLockManager.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/ReservationLockManager.java
@@ -1,0 +1,94 @@
+package com.project.tableforyou.domain.reservationrefactor.service;
+
+import com.project.tableforyou.common.handler.exceptionHandler.error.ErrorCode;
+import com.project.tableforyou.common.handler.exceptionHandler.exception.CustomException;
+import com.project.tableforyou.domain.reservationrefactor.dto.TimeSlotReservationDto;
+import com.project.tableforyou.domain.reservationrefactor.redis.util.constants.ReservationConstants;
+import com.project.tableforyou.domain.reservationrefactor.service.queue.QueueReservationCommandService;
+import com.project.tableforyou.domain.reservationrefactor.service.timeslot.TimeSlotReservationCommandService;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationLockManager {
+    private final RedissonClient redissonClient;
+    private final QueueReservationCommandService queueReservationCommandService;
+    private final TimeSlotReservationCommandService timeSlotReservationCommandService;
+
+    // 락 이름 생성 시 사용하는 prefix들
+    private static final String QUEUE = "queue:";
+    private static final String TIME_SLOT = "timeslot:";
+    private static final String LOCK = "lock:";
+
+    private static final long WAIT_TIME = 5L;     // 락 획득을 기다리는 최대 시간 (초)
+    private static final long LEASE_TIME = 5L;    // 락 소유 시간 (초)
+
+    /**
+     * 일반 대기열(Queue) 예약 저장 - Redisson FairLock 사용
+     *
+     * @param userId       사용자 ID
+     * @param username     사용자 이름
+     * @param restaurantId 음식점 ID
+     * @return 예약 번호
+     */
+    public int saveQueueReservation(Long userId, String username, Long restaurantId) {
+        String key = ReservationConstants.RESERVATION_KEY_PREFIX + QUEUE + restaurantId;
+        RLock lock = redissonClient.getFairLock(LOCK + key);
+        try {
+            // 락 시도
+            boolean available = lock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS);
+            if (!available) {   // 획득 실패 시 (대기 시간 동안)
+                throw new CustomException(ErrorCode.LOCK_ACQUISITION_ERROR);
+            }
+
+            return queueReservationCommandService.create(userId, username, restaurantId);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CustomException(ErrorCode.THREAD_INTERRUPTED);
+        } finally {
+            // 현재 쓰레드가 락을 보유 중이면 해제
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+
+    /**
+     * 시간대(TimeSlot) 예약 저장 - Redisson FairLock 사용
+     *
+     * @param userId       사용자 ID
+     * @param username     사용자 이름
+     * @param restaurantId 음식점 ID
+     * @param createReq    예약 요청 정보 (날짜, 시간, 좌석 수 포함)
+     */
+    public void saveTimeSlotReservation(Long userId, String username, Long restaurantId, TimeSlotReservationDto.Create createReq) {
+        String key = ReservationConstants.RESERVATION_KEY_PREFIX + TIME_SLOT + restaurantId;
+        RLock lock = redissonClient.getFairLock(LOCK + key);
+
+        try {
+            // 락 시도
+            boolean available = lock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS);
+            if (!available) {   // 획득 실패 시 (대기 시간 동안)
+                throw new CustomException(ErrorCode.LOCK_ACQUISITION_ERROR);
+            }
+
+            timeSlotReservationCommandService.create(
+                    userId, username, restaurantId,
+                    createReq.availableSeats(), createReq.date(), createReq.timeSlot()
+            );
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CustomException(ErrorCode.THREAD_INTERRUPTED);
+        } finally {
+            // 현재 쓰레드가 락을 보유 중이면 해제
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/queue/QueueReservationCacheSyncService.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/queue/QueueReservationCacheSyncService.java
@@ -1,0 +1,135 @@
+package com.project.tableforyou.domain.reservationrefactor.service.queue;
+
+import com.project.tableforyou.common.handler.exceptionHandler.error.ErrorCode;
+import com.project.tableforyou.common.handler.exceptionHandler.exception.CustomException;
+import com.project.tableforyou.domain.reservationrefactor.cache.QueueReservationCache;
+import com.project.tableforyou.domain.reservationrefactor.entity.QueueReservation;
+import com.project.tableforyou.domain.reservationrefactor.redis.queue.QueueReservationRedisService;
+import com.project.tableforyou.domain.reservationrefactor.repository.QueueReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class QueueReservationCacheSyncService {
+    private final QueueReservationRepository queueReservationRepository;
+    private final QueueReservationRedisService queueReservationRedisService;
+
+    /**
+     * 예약 번호 생성 카운터를 Redis에 동기화
+     *
+     * @param restaurantId 음식점 ID
+     * @return 현재까지의 예약 수 + 1
+     */
+    public int syncReservationsToCacheIfAbsent(Long restaurantId) {
+        int count = queueReservationRepository.countByRestaurantIdAndDate(
+                restaurantId, LocalDate.now()
+        ) + 1;
+
+        // Redis 카운터가 비정상 상태일 때만 동기화
+        if (count != 1) {
+            queueReservationRedisService.setReservationNumberCounter(restaurantId, count);
+        }
+
+        return count;
+    }
+
+    /**
+     * 입장 인원 수 조회 및 Redis에 동기화
+     *
+     * @param restaurantId 음식점 ID
+     * @return 입장 완료된 인원 수
+     */
+    public int getOrLoadEnteredCount(Long restaurantId) {
+        int count = queueReservationRedisService.getEnteredCount(restaurantId);
+
+        if (count == 0) {       // count가 0이면, 레디스 값 손실 가능성 -> DB에서 동기화 시도
+            count = queueReservationRepository.countByRestaurantIdAndDateAndIsEnteredTrue(
+                    restaurantId, LocalDate.now());
+            if (count != 0) {   // Redis 카운터가 비정상 상태일 때만 동기화
+                queueReservationRedisService.setEnteredCount(restaurantId, count);
+            }
+        }
+
+        return count;
+    }
+
+    /**
+     * 취소 인원 수 조회 및 Redis에 동기화
+     *
+     * @param restaurantId 음식점 ID
+     * @return 취소된 인원 수
+     */
+    public int getOrLoadCanceledCount(Long restaurantId) {
+        int count = queueReservationRedisService.getCanceledCount(restaurantId);
+
+        if (count == 0) {       // count가 0이면, 레디스 값 손실 가능성 -> DB에서 동기화 시도
+            count = queueReservationRepository.countByRestaurantIdAndDateAndIsCanceledTrue(
+                    restaurantId, LocalDate.now());
+            if (count != 0) {   // Redis 카운터가 비정상 상태일 때만 동기화
+                queueReservationRedisService.setCanceledCount(restaurantId, count);
+            }
+        }
+
+        return count;
+    }
+
+    /**
+     * Redis에 예약 정보가 없지만 DB에 이미 존재하는 경우,
+     * DB에서 해당 유저의 예약 정보를 복원한 뒤 예외 반환
+     *
+     * @param userId       사용자 ID
+     * @param restaurantId 음식점 ID
+     */
+    public void restoreUserReservationToCache(Long userId, Long restaurantId) {
+        Optional<QueueReservation> queueReservation =
+                queueReservationRepository.findByUserIdAndRestaurantIdAndDateAndIsCanceledFalse(
+                        userId, restaurantId, LocalDate.now()
+                );
+
+        if (queueReservation.isPresent()) {
+            QueueReservation reservation = queueReservation.get();
+
+            queueReservationRedisService.saveReservation(
+                    restaurantId,
+                    QueueReservationCache.of(
+                            reservation.getUserId(),
+                            reservation.getUsername(),
+                            reservation.getReservationNumber()
+                    )
+            );
+
+            throw new CustomException(ErrorCode.ALREADY_USER_RESERVATION);
+        }
+    }
+
+    /**
+     * Redis에 유저 예약 정보가 없을 때 DB에서 강제로 캐싱하고 예약번호 반환
+     *
+     * @param userId       사용자 ID
+     * @param restaurantId 음식점 ID
+     * @return 해당 유저의 예약번호
+     */
+    @Transactional
+    public int syncUserReservationToCacheIfAbsent(Long userId, Long restaurantId) {
+        QueueReservation queueReservation =
+                queueReservationRepository.findByUserIdAndRestaurantIdAndDateAndIsCanceledFalse(
+                        userId, restaurantId, LocalDate.now()
+                ).orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        queueReservationRedisService.saveReservation(
+                restaurantId,
+                QueueReservationCache.of(
+                        queueReservation.getUserId(),
+                        queueReservation.getUsername(),
+                        queueReservation.getReservationNumber()
+                )
+        );
+
+        return queueReservation.getReservationNumber();
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/queue/QueueReservationCommandService.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/queue/QueueReservationCommandService.java
@@ -1,0 +1,109 @@
+package com.project.tableforyou.domain.reservationrefactor.service.queue;
+
+import com.project.tableforyou.common.handler.exceptionHandler.error.ErrorCode;
+import com.project.tableforyou.common.handler.exceptionHandler.exception.CustomException;
+import com.project.tableforyou.domain.reservationrefactor.cache.QueueReservationCache;
+import com.project.tableforyou.domain.reservationrefactor.entity.QueueReservation;
+import com.project.tableforyou.domain.reservationrefactor.redis.queue.QueueReservationRedisService;
+import com.project.tableforyou.domain.reservationrefactor.repository.QueueReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class QueueReservationCommandService {
+    private final QueueReservationRepository queueReservationRepository;
+    private final QueueReservationRedisService queueReservationRedisService;
+    private final QueueReservationCacheSyncService queueReservationCacheSyncService;
+
+    /**
+     * 대기열 예약 생성
+     * - Redis 캐시 확인 후 없다면 DB 동기화 시도
+     * - 예약 번호 계산 후 DB 및 Redis 저장
+     *
+     * @param userId       사용자 ID
+     * @param username     사용자 이름
+     * @param restaurantId 음식점 ID
+     * @return 예약 번호
+     */
+    @Transactional
+    public int create(Long userId, String username, Long restaurantId) {
+        // Redis에 이미 예약된 사용자라면 예외 발생
+        if (!queueReservationRedisService.isAlreadyReserved(userId, restaurantId)) {
+            // 캐시가 없을 경우 DB에서 확인.
+            queueReservationCacheSyncService.restoreUserReservationToCache(userId, restaurantId);
+        } else {
+            throw new CustomException(ErrorCode.ALREADY_USER_RESERVATION);
+        }
+
+        // 예약 번호 계산
+        int reservationNumber = getReservationCount(restaurantId);
+
+        QueueReservation queueReservation = QueueReservation.builder()
+                .userId(userId)
+                .username(username)
+                .restaurantId(restaurantId)
+                .reservationNumber(reservationNumber)
+                .date(LocalDate.now())
+                .build();
+
+        // DB에 예약 저장
+        queueReservationRepository.save(queueReservation);
+
+        // Redis에 캐싱
+        queueReservationRedisService.saveReservation(
+                restaurantId,
+                QueueReservationCache.of(userId, username, reservationNumber)
+        );
+
+        return reservationNumber;
+    }
+
+    /**
+     * 예약 수를 계산
+     * - count가 1이라면 DB에서 동기화 실행 (레디스 값 손실 가능성)
+     */
+    private int getReservationCount(Long restaurantId) {
+        int count = queueReservationRedisService.generateNextReservationNumber(restaurantId);
+        if (count == 1) {
+            count = queueReservationCacheSyncService.syncReservationsToCacheIfAbsent(restaurantId);
+        }
+
+        return count;
+    }
+
+    /**
+     * 대기열 예약 취소
+     * - DB의 예약을 취소 처리
+     * - Redis에서 삭제 및 삭제 카운트 증가
+     */
+    @Transactional
+    public void cancel(Long userId, Long restaurantId) {
+        QueueReservation queueReservation =
+                queueReservationRepository.findByUserIdAndRestaurantIdAndDateAndIsCanceledFalse(
+                        userId, restaurantId, LocalDate.now()
+                ).orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        queueReservation.cancelReservation();
+        queueReservationRedisService.cancelReservation(userId, restaurantId);
+    }
+
+    /**
+     * 대기열 입장 처리
+     * - DB에 입장 상태 저장
+     * - Redis에서 캐시 삭제 및 입장 카운트 증가
+     */
+    @Transactional
+    public void markAsEntered(Long userId, Long restaurantId) {
+        QueueReservation queueReservation =
+                queueReservationRepository.findByUserIdAndRestaurantIdAndDateAndIsCanceledFalse(
+                        userId, restaurantId, LocalDate.now()
+                ).orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        queueReservation.enterRestaurant();
+        queueReservationRedisService.markAsEntered(userId, restaurantId);
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/queue/QueueReservationQueryService.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/queue/QueueReservationQueryService.java
@@ -1,0 +1,43 @@
+package com.project.tableforyou.domain.reservationrefactor.service.queue;
+
+import com.project.tableforyou.domain.reservationrefactor.cache.QueueReservationCache;
+import com.project.tableforyou.domain.reservationrefactor.redis.queue.QueueReservationRedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QueueReservationQueryService {
+    private final QueueReservationRedisService queueReservationRedisService;
+    private final QueueReservationCacheSyncService queueReservationCacheSyncService;
+
+    /**
+     * 현재 사용자의 대기열 순번을 계산하여 반환
+     * - Redis에 예약 정보가 없으면 DB 동기화 시도
+     * - 입장 인원 및 취소 인원을 고려하여 실제 대기 순번 계산
+     *
+     * @param userId       사용자 ID
+     * @param restaurantId 음식점 ID
+     * @return 대기 순번 (예약번호 - 입장 수 - 취소 수)
+     */
+    public int getUserWaitingPosition(Long userId, Long restaurantId) {
+        // Redis에서 사용자의 예약 캐시 조회
+        QueueReservationCache reservation = queueReservationRedisService.getReservation(userId, restaurantId);
+        int reservationNumber;
+
+        if (reservation == null) {      // 캐시 미존재 시, DB 동기화 시도
+            reservationNumber = queueReservationCacheSyncService.syncUserReservationToCacheIfAbsent(userId, restaurantId);
+        } else {
+            reservationNumber = reservation.reservationNumber();
+        }
+
+        // 입장 인원 수 조회 (캐시 없으면 DB 조회 후 Redis에 저장)
+        int entered = queueReservationCacheSyncService.getOrLoadEnteredCount(restaurantId);
+
+        // 취소 인원 수 조회 (캐시 없으면 DB 조회 후 Redis에 저장)
+        int canceled = queueReservationCacheSyncService.getOrLoadCanceledCount(restaurantId);
+
+        return reservationNumber - entered - canceled;
+    }
+}
+

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/timeslot/TimeSlotReservationCacheSyncService.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/timeslot/TimeSlotReservationCacheSyncService.java
@@ -1,0 +1,95 @@
+package com.project.tableforyou.domain.reservationrefactor.service.timeslot;
+
+import com.project.tableforyou.common.handler.exceptionHandler.error.ErrorCode;
+import com.project.tableforyou.common.handler.exceptionHandler.exception.CustomException;
+import com.project.tableforyou.domain.reservation.entity.TimeSlot;
+import com.project.tableforyou.domain.reservationrefactor.cache.TimeSlotReservationCache;
+import com.project.tableforyou.domain.reservationrefactor.entity.TimeSlotReservation;
+import com.project.tableforyou.domain.reservationrefactor.redis.timeslot.TimeSlotReservationRedisService;
+import com.project.tableforyou.domain.reservationrefactor.repository.TimeSlotReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TimeSlotReservationCacheSyncService {
+    private final TimeSlotReservationRepository timeSlotReservationRepository;
+    private final TimeSlotReservationRedisService timeSlotReservationRedisService;
+
+    /**
+     * 예약 번호 생성 카운터를 Redis에 동기화
+     *
+     * @param restaurantId 음식점 ID
+     * @param date         예약 날짜
+     * @param timeSlot     예약 타임슬롯
+     * @return Redis에 설정할 다음 예약 번호
+     */
+    public int syncReservationsToCacheIfAbsent(Long restaurantId, LocalDate date, TimeSlot timeSlot) {
+        int count = timeSlotReservationRepository.countByRestaurantIdAndDateAndTimeSlotAndIsCanceledFalse(
+                restaurantId, date, timeSlot
+        ) + 1;
+
+        // Redis 카운터가 비정상 상태일 때만 동기화
+        if (count != 1) {
+            timeSlotReservationRedisService.setReservationNumberCounter(restaurantId, date.toString(), timeSlot, count);
+        }
+
+        return count;
+    }
+
+    /**
+     * Redis에 예약 정보가 없지만 DB에 이미 존재하는 경우,
+     * DB에서 해당 유저의 예약 정보를 복원한 뒤 예외 반환
+     *
+     * @param userId       사용자 ID
+     * @param restaurantId 음식점 ID
+     * @param date         예약 날짜
+     * @param timeSlot     예약 타임슬롯
+     */
+    public void restoreUserReservationToCache(Long userId, Long restaurantId, LocalDate date, TimeSlot timeSlot) {
+        Optional<TimeSlotReservation> timeSlotReservation =
+                timeSlotReservationRepository.findByUserIdAndRestaurantIdAndDateAndTimeSlotAndIsCanceledFalse(
+                        userId, restaurantId, date, timeSlot
+                );
+
+        if (timeSlotReservation.isPresent()) {
+            TimeSlotReservation reservation = timeSlotReservation.get();
+
+            timeSlotReservationRedisService.saveReservation(
+                    restaurantId,
+                    date.toString(),
+                    TimeSlotReservationCache.of(reservation.getUserId(), reservation.getUsername(), timeSlot)
+            );
+
+            throw new CustomException(ErrorCode.ALREADY_USER_RESERVATION);
+        }
+    }
+
+    /**
+     * Redis에 유저 예약 정보가 없을 때 DB에서 강제로 캐싱
+     * - 예약이 없으면 예외 발생
+     * - 예약이 있으면 Redis에 저장 후 정상 종료
+     *
+     * @param userId       사용자 ID
+     * @param restaurantId 음식점 ID
+     * @param date         예약 날짜
+     * @param timeSlot     예약 타임슬롯
+     */
+    @Transactional
+    public void syncUserReservationToCacheIfAbsent(Long userId, Long restaurantId, LocalDate date, TimeSlot timeSlot) {
+        TimeSlotReservation reservation =
+                timeSlotReservationRepository.findByUserIdAndRestaurantIdAndDateAndTimeSlotAndIsCanceledFalse(
+                        userId, restaurantId, date, timeSlot
+                ).orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        timeSlotReservationRedisService.saveReservation(
+                restaurantId,
+                date.toString(),
+                TimeSlotReservationCache.of(reservation.getUserId(), reservation.getUsername(), timeSlot)
+        );
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/timeslot/TimeSlotReservationCommandService.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/timeslot/TimeSlotReservationCommandService.java
@@ -1,0 +1,123 @@
+package com.project.tableforyou.domain.reservationrefactor.service.timeslot;
+
+import com.project.tableforyou.common.handler.exceptionHandler.error.ErrorCode;
+import com.project.tableforyou.common.handler.exceptionHandler.exception.CustomException;
+import com.project.tableforyou.domain.reservation.entity.TimeSlot;
+import com.project.tableforyou.domain.reservationrefactor.cache.TimeSlotReservationCache;
+import com.project.tableforyou.domain.reservationrefactor.dto.TimeSlotReservationDto;
+import com.project.tableforyou.domain.reservationrefactor.entity.TimeSlotReservation;
+import com.project.tableforyou.domain.reservationrefactor.redis.timeslot.TimeSlotReservationRedisService;
+import com.project.tableforyou.domain.reservationrefactor.repository.TimeSlotReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class TimeSlotReservationCommandService {
+    private final TimeSlotReservationRepository timeSlotReservationRepository;
+    private final TimeSlotReservationRedisService timeSlotReservationRedisService;
+    private final TimeSlotReservationCacheSyncService timeSlotReservationCacheSyncService;
+
+    /**
+     * 시간대 예약 생성
+     * - Redis 캐시 확인 후 없다면 DB 동기화 시도
+     * - 예약 인원이 초과되면 예외 발생
+     * - DB 및 Redis에 예약 정보 저장
+     *
+     * @param userId         사용자 ID
+     * @param username       사용자 이름
+     * @param restaurantId   음식점 ID
+     * @param availableSeats 해당 타임슬롯 총 예약 가능 인원
+     * @param date           예약 날짜
+     * @param timeSlot       예약 타임슬롯
+     */
+    @Transactional
+    public void create(Long userId, String username, Long restaurantId, int availableSeats, LocalDate date, TimeSlot timeSlot) {
+        // Redis에 없을 경우 DB 복원 시도 (있다면 예외 발생)
+        if (!timeSlotReservationRedisService.isAlreadyReserved(userId, restaurantId, date.toString(), timeSlot)) {
+            timeSlotReservationCacheSyncService.restoreUserReservationToCache(userId, restaurantId, date, timeSlot);
+        } else {
+            throw new CustomException(ErrorCode.ALREADY_USER_RESERVATION);
+        }
+
+        // 좌석 수 검증 (카운터 증가 후 초과 여부 확인)
+        validateAvailableSeats(restaurantId, date, timeSlot, availableSeats);
+
+        TimeSlotReservation timeSlotReservation = TimeSlotReservation.builder()
+                .userId(userId)
+                .username(username)
+                .restaurantId(restaurantId)
+                .date(date)
+                .timeSlot(timeSlot)
+                .build();
+
+        // DB에 저장
+        timeSlotReservationRepository.save(timeSlotReservation);
+
+        // Redis에 캐싱
+        timeSlotReservationRedisService.saveReservation(
+                restaurantId,
+                date.toString(),
+                TimeSlotReservationCache.of(userId, username, timeSlot));
+    }
+
+    /**
+     * 예약 가능한 좌석 수 검증
+     * - Redis 카운터를 먼저 증가시키고
+     * - 카운터가 1이라면 DB에서 동기화 실행 (레디스 값 손실 가능성)
+     * - 초과 시 예외 발생
+     */
+    private void validateAvailableSeats(Long restaurantId, LocalDate date, TimeSlot timeSlot, int availableSeats) {
+        int count = timeSlotReservationRedisService.generateNextReservationNumber(restaurantId, date.toString(), timeSlot);
+        if (count == 1) {
+            count = timeSlotReservationCacheSyncService.syncReservationsToCacheIfAbsent(restaurantId, date, timeSlot);
+        }
+
+        if (count > availableSeats) {
+            throw new CustomException(ErrorCode.NO_AVAILABLE_SEATS);
+        }
+    }
+
+    /**
+     * 시간대 예약 취소
+     * - DB의 예약을 취소 처리
+     * - Redis에서 삭제
+     *
+     * @param userId       사용자 ID
+     * @param restaurantId 음식점 ID
+     * @param request      예약 취소 요청 정보 (날짜, 타임슬롯)
+     */
+    @Transactional
+    public void cancel(Long userId, Long restaurantId, TimeSlotReservationDto.Request request) {
+        TimeSlotReservation timeSlotReservation =
+                timeSlotReservationRepository.findByUserIdAndRestaurantIdAndDateAndTimeSlotAndIsCanceledFalse(
+                        userId, restaurantId, request.date(), request.timeSlot()
+                ).orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        timeSlotReservation.cancelReservation();
+        timeSlotReservationRedisService.cancelReservation(
+                userId, restaurantId, request.date().toString(), request.timeSlot()
+        );
+    }
+
+    /**
+     * 시간대 예약 입장 처리
+     * - DB에 입장 상태 저장
+     *
+     * @param userId       사용자 ID
+     * @param restaurantId 음식점 ID
+     * @param request      입장 요청 정보 (날짜, 타임슬롯)
+     */
+    @Transactional
+    public void markAsEntered(Long userId, Long restaurantId, TimeSlotReservationDto.Request request) {
+        TimeSlotReservation timeSlotReservation =
+                timeSlotReservationRepository.findByUserIdAndRestaurantIdAndDateAndTimeSlotAndIsCanceledFalse(
+                        userId, restaurantId, request.date(), request.timeSlot()
+                ).orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        timeSlotReservation.enterRestaurant();
+    }
+}

--- a/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/timeslot/TimeSlotReservationQueryService.java
+++ b/src/main/java/com/project/tableforyou/domain/reservationrefactor/service/timeslot/TimeSlotReservationQueryService.java
@@ -1,0 +1,42 @@
+package com.project.tableforyou.domain.reservationrefactor.service.timeslot;
+
+import com.project.tableforyou.domain.reservation.entity.TimeSlot;
+import com.project.tableforyou.domain.reservationrefactor.redis.timeslot.TimeSlotReservationRedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class TimeSlotReservationQueryService {
+    private final TimeSlotReservationRedisService timeSlotReservationRedisService;
+    private final TimeSlotReservationCacheSyncService timeSlotReservationCacheSyncService;
+
+    /**
+     * 사용자의 예약 여부를 확인하고, Redis에 없으면 DB에서 복원
+     * - Redis에 예약 정보가 없으면 DB 동기화 시도
+     *
+     * @param userId       사용자 ID
+     * @param restaurantId 음식점 ID
+     * @param date         예약 날짜
+     * @param timeSlot     예약 타임슬롯
+     * @return 항상 true (예외가 발생하지 않으면 예약이 존재함을 의미)
+     */
+    public boolean confirmOrCacheMyReservation(Long userId, Long restaurantId, LocalDate date, TimeSlot timeSlot) {
+        // Redis에 사용자 예약 정보가 없을 경우, DB에서 동기화 시도
+        if (!timeSlotReservationRedisService.isAlreadyReserved(userId, restaurantId, date.toString(), timeSlot)) {
+            timeSlotReservationCacheSyncService./**
+             * Redis에 유저 예약 정보가 없을 때 DB에서 강제로 캐싱하고 예약번호 반환
+             * - 대기 순번 조회 시 사용됨
+             *
+             * @param userId       사용자 ID
+             * @param restaurantId 음식점 ID
+             * @return 해당 유저의 예약번호
+             */syncUserReservationToCacheIfAbsent(userId, restaurantId, date, timeSlot);
+        }
+
+        // Redis에 예약 정보가 존재하거나, 동기화 성공 시 항상 true 반환
+        return true;
+    }
+}


### PR DESCRIPTION
## 개요
현재 예약 로직은 단순히 Redis에서만 관리 (`domain.reservation`패키지 참고)
주요 로직인 예약을 휘발성 캐시에만 저장하면 데이터 손실 가능성 존재.
캐시 어사이드 (Cache-Aside) 형식으로 수정 진행
(기존 로직에 대해 연동 오류 가능성으로, 새로운 패키지 `domain.reservationrefactor`에 구현)

## 구현 사항
- 예약 Entity 구현
    - 번호표 예약(Queue) Entity 구현 (006977422eb81cd330c5dab3169f9df917f9f842)
    - 시간대 예약(TimeSlot) Entity 구현 (6a5201694512ada9bdc8e12c1c0d24b7b53774ba)
- 예약 쓰기 연산 구현 (생성, 취소, 입장)
    - 번호표 예약(Queue) 쓰기연산(생성, 취소, 입장) 로직 구현 (9c2d7e9f525ee17d67c9958b88be3f535a48342e)
    - 시간대 예약(TimeSlot) 쓰기연산(생성, 취소, 입장) 로직 구현 (a77afc04ebac801364876400cecfacba1104b26b)
- 예약 읽기 연산 구현 (조회)
    - 번호표 예약(Queue) 읽기연산(조회) 로직 구현 (9243e385ae7b5c9a40a5e9c57cc592ffa49c49ec)
    - 시간대 예약(TimeSlot) 읽기연산(조회) 로직 구현 (fda7170937d9a805561f0df2360edf281a07ebb0)
- Redis <-> DB 동기화 로직 구현
    - 번호표 예약(Queue) Redis, DB 동기화 로직 구현 (b0047bd85994f8f171d4dda0bd823d85e1151a5a)
    - 시간대 예약(TimeSlot) Redis, DB 동기화 로직 구현 (3bc3da6d5b08d48a70c4048974e55d8a3239d47d)
- 동시성 문제 해결을 위한 예약 락 설정 (5b014cd43735b76af0d1301ab90457d9388f98a6)

## 구현 내용
[해당 내용을 작성한 블로그](https://velog.io/@pdy000726/%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%9C%A0%EC%8B%A4%EC%9D%84-%ED%94%BC%ED%95%98%EA%B8%B0-%EC%9C%84%ED%95%9C-%EC%BA%90%EC%8B%9C-%EC%A0%84%EB%9E%B5-%EB%A6%AC%EB%94%94%EC%9E%90%EC%9D%B8)

1. 조회 : `캐시 어사이드 (Cache-Aside)` 개념 사용. Redis 캐시를 먼저 조회 후, 없다면 애플리케이션에서 DB 저장소에 접근해 가지고 와 캐시에 저장 후 반환.
2. 데이터 삽입 : `Write-Through` 유사 개념 사용. 캐시에 저장하면, 캐시가 DB에 저장하는 `Write-Through`와 비슷하게, 애플리케이션이 DB에 저장한 후, Redis 캐시에 저장 (가게 주인 등이 전체 예약자 불러오는 경우, 예약 내역에 대한 빠른 조회를 위해)

### 📌 예약 생성 Sequence Diagram
|<img width="571" height="743" alt="queue-예약" src="https://github.com/user-attachments/assets/13cff3ad-5760-46c7-8d18-0b84808e5605" />|<img width="703" height="815" alt="timeslot-예약" src="https://github.com/user-attachments/assets/443b3fe7-eefe-4c39-81a3-138f6d2de4c3" />|
|---|---|
| 번호표(Queue) 예약 생성 | 시간대(TimeSlot) 예약 생성 |

### 📌 예약 조회 Sequence Diagram
|<img width="383" height="629" alt="queue-조회1" src="https://github.com/user-attachments/assets/50158f42-1111-47d1-bd00-f1d8f4a57330" />|<img width="862" height="524" alt="timeslot-조회" src="https://github.com/user-attachments/assets/4a0d799c-0526-4786-80bd-595cc6770bff" />|
|---|---|
| 번호표(Queue) 예약 조회 | 시간대(TimeSlot) 예약 조회 |

### 📌 예약 취소 Sequence Diagram
|<img width="869" height="395" alt="queue-취소" src="https://github.com/user-attachments/assets/b56a77ab-d8ba-4aff-bf80-c62a17460c95" />|<img width="971" height="349" alt="timeslot-취소" src="https://github.com/user-attachments/assets/8d125424-050a-4d63-895d-bb1eac52753d" />|
|---|---|
| 번호표(Queue) 예약 취소 | 시간대(TimeSlot) 예약 취소 |

### 📌 예약 입장 Sequence Diagram
|<img width="795" height="362" alt="queue-입장" src="https://github.com/user-attachments/assets/6cfc0d94-0db0-46c2-a481-efb8b7525f93" />|<img width="959" height="362" alt="timeslot-입장" src="https://github.com/user-attachments/assets/c627488a-fffb-4abb-ac5a-7653242f9dc7" />|
|---|---|
| 번호표(Queue) 예약 입장 | 시간대(TimeSlot) 예약 입장 |